### PR TITLE
Use command when relying on external executables

### DIFF
--- a/notifyre.fish
+++ b/notifyre.fish
@@ -6,12 +6,12 @@ function notifyre
     if test $CMD_DURATION
         if test $CMD_DURATION -gt (math "1000 * $timeout") # time set for notification
             set secs (math "$CMD_DURATION / 1000")
-            notify-send "Terminal in "(prompt_pwd) "$history[1] completed in $secs seconds"  -i ~/terminal.png -t 2
+            command notify-send "Terminal in "(prompt_pwd) "$history[1] completed in $secs seconds"  -i ~/terminal.png -t 2
         end
 
         if test $CMD_DURATION -gt (math "1000 * $ring_timeout") # time set for ring
             set secs (math "$CMD_DURATION / 1000")
-            paplay $ALERT
+            command paplay $ALERT
         end
     end
 end

--- a/prompt_pwd.fish
+++ b/prompt_pwd.fish
@@ -15,9 +15,9 @@ function prompt_pwd --description "Print the current working directory, shortene
     set -l tmp (string replace -r '^'"$realhome"'($|/)' '~$1' $PWD)
 
     if [ $fish_prompt_pwd_dir_length -eq 0 ]
-        echo $tmp
+        command echo $tmp
     else
         # Shorten to at most $fish_prompt_pwd_dir_length characters per directory
-        string replace -ar '(\.?[^/]{'"$fish_prompt_pwd_dir_length"'})[^/]*/' '$1/' $tmp
+        command string replace -ar '(\.?[^/]{'"$fish_prompt_pwd_dir_length"'})[^/]*/' '$1/' $tmp
     end
 end

--- a/prompt_pwd.fish
+++ b/prompt_pwd.fish
@@ -18,6 +18,6 @@ function prompt_pwd --description "Print the current working directory, shortene
         command echo $tmp
     else
         # Shorten to at most $fish_prompt_pwd_dir_length characters per directory
-        command string replace -ar '(\.?[^/]{'"$fish_prompt_pwd_dir_length"'})[^/]*/' '$1/' $tmp
+        builtin string replace -ar '(\.?[^/]{'"$fish_prompt_pwd_dir_length"'})[^/]*/' '$1/' $tmp
     end
 end


### PR DESCRIPTION
Whenever a command is called without the `command` prefix in Fish, one cannot guarantee what will get executed. See https://fishshell.com/docs/2.0/commands.html#command for details.

If for some reason, a user created a function named, for example, `notify-send` then calling `notify-send` without the `command` prefix will run the user's function.
Best case scenario the user set the function to a non-disruptive behavior (adding some logging, sending an email, ... while still calling `notify-send` with the passed arguments).
Worst case scenario the user set the function to do something totally unexpected (for example calling `ls` instead of `notify-send`.

The current code relies on `notify-send` (and a few others) to be their default built-in versions, the only way to ensure that is to add the `command` prefix.